### PR TITLE
Update documentation to resemble correct defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ List of variables used in `config/docker`
 
 | Variable | Default |
 | -------- | ------- |
-| APP_DEBUG | true |
+| APP_DEBUG | false |
 | APP_URL | http://localhost |
 | APP_KEY | 0123456789ABCDEFGHIJKLMNOPQRSTUV |
 | CACHE_STORE | file |


### PR DESCRIPTION
In 53578238c1, `APP_DEBUG` was defaulted to `false`.

Developers will be left wondering why e.g. `dump()`ing variables won't work, because they assume that debug mode is enabled.