### PR TITLE
Added CMS_DATABASE_TEMPLATES env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ List of variables used in `config/docker`
 | CMS_BACKEND_FORCE_SECURE | false |
 | CMS_BACKEND_SKIN | Backend\Skins\Standard |
 | CMS_BACKEND_URI | backend |
+| CMS_DATABASE_TEMPLATES | false |
 | CMS_DISABLE_CORE_UPDATES | true |
 | CMS_EDGE_UPDATES | false  (true in `edge` images) |
 | CMS_LINK_POLICY | detect |

--- a/config/docker/cms.php
+++ b/config/docker/cms.php
@@ -13,6 +13,7 @@ return [
     'backendSkin' => env('CMS_BACKEND_SKIN', 'Backend\Skins\Standard'),
     'disableCoreUpdates' => env('CMS_DISABLE_CORE_UPDATES', true),
     'linkPolicy' => env('CMS_LINK_POLICY', 'detect'),
+    'databaseTemplates' => env('CMS_DATABASE_TEMPLATES', false),
     'defaultMask' => [
         'file' => env('CMS_DEFAULT_MASK_FILE', '664'),
         'folder' =>  env('CMS_DEFAULT_MASK_FOLDER', '775'),


### PR DESCRIPTION
The `cms.databaseTemplates` setting allows to store theme data in the DB. To create proper ephemeral containers this setting should be configurable via an env variable.

I have added the `CMS_DATABASE_TEMPLATES` variable to achieve this in this PR.